### PR TITLE
Use jodconverter REST api project instead of spring-boot one with UI

### DIFF
--- a/jodconverter-docker/build.gradle
+++ b/jodconverter-docker/build.gradle
@@ -9,7 +9,7 @@ configurations {
 }
 
 dependencies {
-    jodConverterWar project(path: ':jodconverter-samples:jodconverter-sample-spring-boot', configuration: 'myWar')
+    jodConverterWar project(path: ':jodconverter-samples:jodconverter-sample-rest', configuration: 'myWar')
 }
 
 

--- a/jodconverter-samples/jodconverter-sample-rest/build.gradle
+++ b/jodconverter-samples/jodconverter-sample-rest/build.gradle
@@ -18,12 +18,17 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'org.springframework.boot'
+apply plugin: 'war'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 repositories {
   mavenCentral()
+}
+
+configurations {
+  myWar
 }
 
 dependencies {
@@ -33,4 +38,8 @@ dependencies {
   compile 'org.glassfish.jaxb:jaxb-runtime:2.3.0.1'
   compile "io.springfox:springfox-swagger2:$swaggerVersion"
   compile "io.springfox:springfox-swagger-ui:$swaggerVersion"
+}
+
+artifacts {
+  myWar bootWar
 }

--- a/jodconverter-samples/jodconverter-sample-rest/src/main/java/org/jodconverter/sample/springboot/CompatConverterController.java
+++ b/jodconverter-samples/jodconverter-sample-rest/src/main/java/org/jodconverter/sample/springboot/CompatConverterController.java
@@ -1,0 +1,41 @@
+package org.jodconverter.sample.springboot;
+
+import java.util.HashMap;
+import org.jodconverter.office.OfficeManager;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
+
+@Controller
+@RequestMapping("/")
+public class CompatConverterController extends ConverterController {
+
+    /**
+     * Creates a new controller.
+     *
+     * @param officeManager The manager used to execute conversions.
+     */
+    public CompatConverterController(OfficeManager officeManager) {
+        super(officeManager);
+    }
+
+    @GetMapping(value = "/", produces = MediaType.TEXT_PLAIN_VALUE)
+    public Object index() {
+        return new ResponseEntity<>("OK", HttpStatus.OK);
+    }
+
+    @PostMapping(value = "/converter", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    public Object convert(
+            @RequestParam("inputFile") final MultipartFile inputFile,
+            @RequestParam(name = "outputFormat") final String outputFormat) {
+        return convert(inputFile, outputFormat, new HashMap<>());
+    }
+
+
+}

--- a/jodconverter-samples/jodconverter-sample-rest/src/main/java/org/jodconverter/sample/springboot/ConverterController.java
+++ b/jodconverter-samples/jodconverter-sample-rest/src/main/java/org/jodconverter/sample/springboot/ConverterController.java
@@ -196,7 +196,7 @@ public class ConverterController {
     }
   }
 
-  private ResponseEntity<Object> convert(
+  protected ResponseEntity<Object> convert(
       final MultipartFile inputFile,
       final String outputFormat,
       final Map<String, String> parameters) {


### PR DESCRIPTION
The spring-boot project with a nice interface redirects you to the homepage without an errorcode when something goes wrong during a conversion.
Together with the remote-jodconverter AMP, this results in the error HTML page being used as a PDF rendition of the document.